### PR TITLE
Added CloudFront to list of available CDNs

### DIFF
--- a/CDN/CDNInterface.php
+++ b/CDN/CDNInterface.php
@@ -34,7 +34,7 @@ interface CDNInterface
      *
      * @param string $string
      *
-     * @return void
+     * @return void|string
      */
     public function flush($string);
 
@@ -43,7 +43,7 @@ interface CDNInterface
      *
      * @param string $string
      *
-     * @return void
+     * @return void|string
      */
     public function flushByString($string);
 
@@ -52,7 +52,16 @@ interface CDNInterface
      *
      * @param array $paths
      *
-     * @return void
+     * @return void|string
      */
     public function flushPaths(array $paths);
+
+    /**
+     * Return the CDN status for given identifier
+     *
+     * @param string  $identifier
+     *
+     * @return string
+     */
+    public function getFlushStatus($identifier);
 }

--- a/CDN/CloudFront.php
+++ b/CDN/CloudFront.php
@@ -1,0 +1,219 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\CDN;
+
+use Aws\CloudFront\CloudFrontClient;
+use Aws\CloudFront\Exception\CloudFrontException;
+
+/**
+ *
+ * From http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html
+ *
+ * Invalidating Objects (Web Distributions Only)
+ * If you need to remove an object from CloudFront edge-server caches before it
+ * expires, you can do one of the following:
+ * Invalidate the object. The next time a viewer requests the object, CloudFront
+ * returns to the origin to fetch the latest version of the object.
+ * Use object versioning to serve a different version of the object that has a
+ * different name. For more information, see Updating Existing Objects Using
+ * Versioned Object Names.
+ * Important:
+ * You can invalidate most types of objects that are served by a web
+ * distribution, but you cannot invalidate media files in the Microsoft Smooth
+ * Streaming format when you have enabled Smooth Streaming for the corresponding
+ * cache behavior. In addition, you cannot invalidate objects that are served by
+ * an RTMP distribution. You can invalidate a specified number of objects each
+ * month for free. Above that limit, you pay a fee for each object that you
+ * invalidate. For example, to invalidate a directory and all of the files in
+ * the directory, you must invalidate the directory and each file individually.
+ * If you need to invalidate a lot of files, it might be easier and less
+ * expensive to create a new distribution and change your object paths to refer
+ * to the new distribution. For more information about the charges for
+ * invalidation, see Paying for Object Invalidation.
+ *
+ * @uses CloudFrontClient for stablish connection with CloudFront service
+ * @link http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.htmlInvalidating Objects (Web Distributions Only)
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class CloudFront implements CDNInterface
+{
+    /**
+     * @var string
+     */
+    protected $path;
+    /**
+     * @var string
+     */
+    protected $key;
+    /**
+     * @var string
+     */
+    protected $secret;
+    /**
+     * @var string
+     */
+    protected $distributionId;
+    /**
+     * @var CloudFrontClient
+     */
+    protected $client;
+
+    /**
+     * @param string $path
+     * @param string $key
+     * @param string $secret
+     * @param string $distributionId
+     */
+    public function __construct($path, $key, $secret, $distributionId)
+    {
+        $this->path = $path;
+        $this->key = $key;
+        $this->secret = $secret;
+        $this->distributionId = $distributionId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath($relativePath, $isFlushable = false)
+    {
+        return sprintf('%s/%s', rtrim($this->path, '/'), ltrim($relativePath, '/'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flushByString($string)
+    {
+        return $this->flushPaths(array($string));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush($string)
+    {
+        return $this->flushPaths(array($string));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @link http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.CloudFront.CloudFrontClient.html#_createInvalidation
+     */
+    public function flushPaths(array $paths)
+    {
+        if (empty($paths)) {
+            throw new \RuntimeException('Unable to flush : expected at least one path');
+        }
+        // Normalizes paths due possible typos since all the CloudFront's
+        // objects starts with a leading slash
+        $normalizedPaths = array_map(function($path) {
+            return '/' . ltrim($path, '/');
+        }, $paths);
+
+        try {
+            $result = $this->getClient()->createInvalidation(array(
+                'DistributionId' => $this->distributionId,
+                'Paths' => array(
+                    'Quantity' => count($normalizedPaths),
+                    'Items' => $normalizedPaths
+                ),
+                'CallerReference' => $this->getCallerReference($normalizedPaths),
+            ));
+
+            if (!in_array($status = $result->get('Status'), array('Completed', 'InProgress'))) {
+                throw new \RuntimeException('Unable to flush : ' . $status);
+            }
+
+            return $result->get('Id');
+        } catch (CloudFrontException $ex) {
+            throw new \RuntimeException('Unable to flush : ' . $ex->getMessage());
+        }
+    }
+
+    /**
+     * Return a CloudFrontClient
+     *
+     * @return CloudFrontClient
+     */
+    private function getClient()
+    {
+        if (!$this->client) {
+            $this->client = CloudFrontClient::factory(array(
+                'key'    => $this->key,
+                'secret' => $this->secret
+            ));
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * For testing only
+     *
+     * @param $client
+     *
+     * @return void
+     */
+    public function setClient($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Generates a valid caller reference from given paths regardless its order
+     *
+     * @param array $paths
+     * @return string a md5 representation
+     */
+    protected function getCallerReference(array $paths)
+    {
+        sort($paths);
+
+        return md5(implode(',', $paths));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \RuntimeException
+     */
+    public function getFlushStatus($identifier)
+    {
+        try {
+            $result = $this->getClient()->getInvalidation(array(
+                'DistributionId' => $this->distributionId,
+                'Id'             => $identifier
+            ));
+
+            return array_search($result->get('Status'), self::getStatusList());
+        } catch (CloudFrontException $ex) {
+            throw new \RuntimeException('Unable to retrieve flush status : ' . $ex->getMessage());
+        }
+    }
+
+    /**
+     * @static
+     * @return array
+     */
+    public static function getStatusList()
+    {
+        // @todo: check for a complete list of available CloudFront statuses
+        return array(
+            self::STATUS_OK       => 'Completed',
+            self::STATUS_TO_SEND  => 'STATUS_TO_SEND',
+            self::STATUS_TO_FLUSH => 'STATUS_TO_FLUSH',
+            self::STATUS_ERROR    => 'STATUS_ERROR',
+            self::STATUS_WAITING  => 'InProgress',
+        );
+    }
+}

--- a/CDN/Fallback.php
+++ b/CDN/Fallback.php
@@ -44,7 +44,7 @@ class Fallback implements CDNInterface
      */
     public function flushByString($string)
     {
-        $this->cdn->flushByString($string);
+        return $this->cdn->flushByString($string);
     }
 
     /**
@@ -52,7 +52,7 @@ class Fallback implements CDNInterface
      */
     public function flush($string)
     {
-        $this->cdn->flush($string);
+        return $this->cdn->flush($string);
     }
 
     /**
@@ -60,6 +60,14 @@ class Fallback implements CDNInterface
      */
     public function flushPaths(array $paths)
     {
-        $this->cdn->flushPaths($paths);
+        return $this->cdn->flushPaths($paths);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFlushStatus($identifier)
+    {
+        return $this->cdn->getFlushStatus($identifier);
     }
 }

--- a/CDN/PantherPortal.php
+++ b/CDN/PantherPortal.php
@@ -119,4 +119,12 @@ class PantherPortal implements CDNInterface
     {
         $this->client = $client;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFlushStatus($identifier)
+    {
+        // nothing to do
+    }
 }

--- a/CDN/Server.php
+++ b/CDN/Server.php
@@ -54,4 +54,12 @@ class Server implements CDNInterface
     {
         // nothing to do
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFlushStatus($identifier)
+    {
+        // nothing to do
+    }
 }

--- a/Command/UpdateCdnStatusCommand.php
+++ b/Command/UpdateCdnStatusCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Command;
+
+use Sonata\MediaBundle\CDN\CDNInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This command can be used to update CDN status for medias that are currently
+ * in status flushing.
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class UpdateCdnStatusCommand extends BaseCommand
+{
+    protected $quiet = false;
+    protected $output;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('sonata:media:update-cdn-status')
+            ->setDescription('Refresh CDN status for medias that are in status flushing')
+            ->setDefinition(array(
+                new InputArgument('providerName', InputArgument::OPTIONAL, 'The provider'),
+                new InputArgument('context', InputArgument::OPTIONAL, 'The context'),
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $provider = $input->getArgument('providerName');
+        if (null === $provider) {
+            $providers = array_keys($this->getMediaPool()->getProviders());
+            $providerKey = $this->getHelperSet()->get('dialog')->select($output, 'Please select the provider', $providers);
+            $provider = $providers[$providerKey];
+        }
+
+        $context  = $input->getArgument('context');
+        if (null === $context) {
+            $contexts = array_keys($this->getMediaPool()->getContexts());
+            $contextKey = $this->getHelperSet()->get('dialog')->select($output, 'Please select the context', $contexts);
+            $context = $contexts[$contextKey];
+        }
+
+        $this->quiet = $input->getOption('quiet');
+        $this->output = $output;
+
+        $medias = $this->getMediaManager()->findBy(array(
+            'providerName'   => $provider,
+            'context'        => $context,
+            'cdnIsFlushable' => true
+        ));
+
+        $this->log(sprintf("Loaded %s medias for updating CDN status (provider: %s, context: %s)", count($medias), $provider, $context));
+
+        foreach ($medias as $media) {
+            $cdn = $this->getMediaPool()->getProvider($media->getProviderName())->getCdn();
+
+            $this->log(sprintf('Refresh CDN status for media "%s" (%d) ', $media->getName(), $media->getId()), false);
+
+            if (!$media->getCdnFlushIdentifier()) {
+                $this->log('<error>Skiping while empty flush identifier</error>');
+                continue;
+            }
+
+            try {
+                $previousStatus = $media->getCdnStatus();
+                if (CDNInterface::STATUS_OK === ($cdnStatus = $cdn->getFlushStatus($media->getCdnFlushIdentifier()))) {
+                    $media->setCdnIsFlushable(false);
+                    $media->setCdnFlushIdentifier(null);
+                    $media->setCdnFlushAt(new \DateTime());
+                }
+                $media->setCdnStatus($cdnStatus);
+
+                if (OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+                    if ($previousStatus == $cdnStatus) {
+                        $this->log(sprintf('No changes (%d)', $cdnStatus));
+                    } elseif(CDNInterface::STATUS_OK === $cdnStatus) {
+                        $this->log(sprintf('<info>Flush completed</info> (%d => %d)', $previousStatus, $cdnStatus));
+                    } else {
+                        $this->log(sprintf('Updated status (%d => %d)', $previousStatus, $cdnStatus));
+                    }
+                }
+            } catch (\Exception $e) {
+                $this->log(sprintf('<error>Unable update CDN status, media: %s - %s </error>', $media->getId(), $e->getMessage()));
+                continue;
+            }
+
+            try {
+                $this->getMediaManager()->save($media);
+            } catch (\Exception $e) {
+                $this->log(sprintf('<error>Unable saving media, media: %s - %s </error>', $media->getId(), $e->getMessage()));
+                continue;
+            }
+        }
+
+        $this->log('Done!');
+    }
+
+    /**
+     * Write a message to the output
+     *
+     * @param string $message
+     *
+     * @return void
+     */
+    protected function log($message, $newLine = true)
+    {
+        if (false === $this->quiet) {
+            if ($newLine) {
+                $this->output->writeln($message);
+            } else {
+                $this->output->write($message);
+            }
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -116,6 +116,15 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
 
+                        ->arrayNode('cloudfront')
+                            ->children()
+                                ->scalarNode('path')->isRequired()->end() // http://xxxxxxxxxxxxxx.cloudfront.net/uploads/media
+                                ->scalarNode('distribution_id')->isRequired()->end()
+                                ->scalarNode('key')->isRequired()->end()
+                                ->scalarNode('secret')->isRequired()->end()
+                            ->end()
+                        ->end()
+
                         ->arrayNode('fallback')
                             ->children()
                                 ->scalarNode('master')->isRequired()->end()

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -309,6 +309,17 @@ class SonataMediaExtension extends Extension
             $container->removeDefinition('sonata.media.cdn.panther');
         }
 
+        if ($container->hasDefinition('sonata.media.cdn.cloudfront') && isset($config['cdn']['cloudfront'])) {
+            $container->getDefinition('sonata.media.cdn.cloudfront')
+                ->replaceArgument(0, $config['cdn']['cloudfront']['path'])
+                ->replaceArgument(1, $config['cdn']['cloudfront']['key'])
+                ->replaceArgument(2, $config['cdn']['cloudfront']['secret'])
+                ->replaceArgument(3, $config['cdn']['cloudfront']['distribution_id'])
+            ;
+        } else {
+            $container->removeDefinition('sonata.media.cdn.cloudfront');
+        }
+
         if ($container->hasDefinition('sonata.media.cdn.fallback') && isset($config['cdn']['fallback'])) {
             $container->getDefinition('sonata.media.cdn.fallback')
                 ->replaceArgument(0, new Reference($config['cdn']['fallback']['master']))
@@ -456,6 +467,7 @@ class SonataMediaExtension extends Extension
     {
         $this->addClassesToCompile(array(
             "Sonata\\MediaBundle\\CDN\\CDNInterface",
+            "Sonata\\MediaBundle\\CDN\\CloudFront",
             "Sonata\\MediaBundle\\CDN\\Fallback",
             "Sonata\\MediaBundle\\CDN\\PantherPortal",
             "Sonata\\MediaBundle\\CDN\\Server",

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -87,6 +87,11 @@ abstract class Media implements MediaInterface
     protected $cdnIsFlushable;
 
     /**
+     * @var string $cdn_flush_identifier
+     */
+    protected $cdnFlushIdentifier;
+
+    /**
      * @var datetime $cdn_flush_at
      */
     protected $cdnFlushAt;
@@ -428,6 +433,22 @@ abstract class Media implements MediaInterface
     public function getCdnIsFlushable()
     {
         return $this->cdnIsFlushable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCdnFlushIdentifier($cdnFlushIdentifier)
+    {
+        $this->cdnFlushIdentifier = $cdnFlushIdentifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCdnFlushIdentifier()
+    {
+        return $this->cdnFlushIdentifier;
     }
 
     /**

--- a/Model/MediaInterface.php
+++ b/Model/MediaInterface.php
@@ -255,6 +255,20 @@ interface MediaInterface
     public function getCdnIsFlushable();
 
     /**
+     * Set cdn_flush_identifier
+     *
+     * @param boolean $cdnFlushIdentifier
+     */
+    public function setCdnFlushIdentifier($cdnFlushIdentifier);
+
+    /**
+     * Get cdn_flush_identifier
+     *
+     * @return string $cdnFlushIdentifier
+     */
+    public function getCdnFlushIdentifier();
+
+    /**
      * Set cdn_flush_at
      *
      * @param \Datetime $cdnFlushAt

--- a/Resources/config/doctrine/BaseMedia.mongodb.xml
+++ b/Resources/config/doctrine/BaseMedia.mongodb.xml
@@ -7,31 +7,32 @@
 
     <mapped-superclass name="Sonata\MediaBundle\Document\BaseMedia" >
 
-        <field name="name"              fieldName="name"                type="string" />
-        <field name="description"       fieldName="description"         type="string" />
-        <field name="enabled"           fieldName="enabled"             type="boolean" />
+        <field name="name"               fieldName="name"                type="string" />
+        <field name="description"        fieldName="description"         type="string" />
+        <field name="enabled"            fieldName="enabled"             type="boolean" />
 
-        <field name="providerName"      fieldName="providerName"        type="string" />
-        <field name="providerStatus"    fieldName="providerStatus"      type="int" />
-        <field name="providerReference" fieldName="providerReference"   type="string" />
-        <field name="providerMetadata"  fieldName="providerMetadata"    type="hash" />
+        <field name="providerName"       fieldName="providerName"        type="string" />
+        <field name="providerStatus"     fieldName="providerStatus"      type="int" />
+        <field name="providerReference"  fieldName="providerReference"   type="string" />
+        <field name="providerMetadata"   fieldName="providerMetadata"    type="hash" />
 
-        <field name="width"             fieldName="width"               type="int" />
-        <field name="height"            fieldName="height"              type="int" />
-        <field name="length"            fieldName="length"              type="float" />
-        <field name="contentType"       fieldName="contentType"         type="string" />
-        <field name="size"              fieldName="size"                type="int" />
+        <field name="width"              fieldName="width"               type="int" />
+        <field name="height"             fieldName="height"              type="int" />
+        <field name="length"             fieldName="length"              type="float" />
+        <field name="contentType"        fieldName="contentType"         type="string" />
+        <field name="size"               fieldName="size"                type="int" />
 
-        <field name="copyright"         fieldName="copyright"           type="string" />
-        <field name="authorName"        fieldName="authorName"          type="string" />
-        <field name="context"           fieldName="context"             type="string" />
+        <field name="copyright"          fieldName="copyright"           type="string" />
+        <field name="authorName"         fieldName="authorName"          type="string" />
+        <field name="context"            fieldName="context"             type="string" />
 
-        <field name="cdnIsFlushable"    fieldName="cdnIsFlushable"      type="boolean" />
-        <field name="cdnFlushAt"        fieldName="cdnFlushAt"          type="date" />
-        <field name="cdnStatus"         fieldName="cdnStatus"           type="int" />
+        <field name="cdnIsFlushable"     fieldName="cdnIsFlushable"      type="boolean" />
+        <field name="cdnFlushIdentifier" fieldName="cdnFlushIdentifier"  type="string" />
+        <field name="cdnFlushAt"         fieldName="cdnFlushAt"          type="date" />
+        <field name="cdnStatus"          fieldName="cdnStatus"           type="int" />
 
-        <field name="updatedAt"         fieldName="updatedAt"     type="date" />
-        <field name="createdAt"         fieldName="createdAt"     type="date" />
+        <field name="updatedAt"          fieldName="updatedAt"     type="date" />
+        <field name="createdAt"          fieldName="createdAt"     type="date" />
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />

--- a/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/Resources/config/doctrine/BaseMedia.orm.xml
@@ -7,32 +7,33 @@
 
     <mapped-superclass name="Sonata\MediaBundle\Entity\BaseMedia" >
 
-        <field name="name"              column="name"           type="string"   nullable="false" length="255"/>
-        <field name="description"       column="description"    type="text"     nullable="true" length="1024"/>
-        <field name="enabled"           column="enabled"        type="boolean"  nullable="false" default="false" />
+        <field name="name"               column="name"           type="string"   nullable="false" length="255"/>
+        <field name="description"        column="description"    type="text"     nullable="true" length="1024"/>
+        <field name="enabled"            column="enabled"        type="boolean"  nullable="false" default="false" />
 
-        <field name="providerName"      column="provider_name"            type="string"   nullable="false" length="255" default="image" />
-        <field name="providerStatus"    column="provider_status"          type="integer"  nullable="false" />
-        <field name="providerReference" column="provider_reference"       type="string"   nullable="false" length="255"/>
-        <field name="providerMetadata"  column="provider_metadata"        type="json"     nullable="true" />
+        <field name="providerName"       column="provider_name"            type="string"   nullable="false" length="255" default="image" />
+        <field name="providerStatus"     column="provider_status"          type="integer"  nullable="false" />
+        <field name="providerReference"  column="provider_reference"       type="string"   nullable="false" length="255"/>
+        <field name="providerMetadata"   column="provider_metadata"        type="json"     nullable="true" />
 
-        <field name="width"             column="width"             type="integer"  nullable="true" />
-        <field name="height"            column="height"            type="integer"  nullable="true" />
-        <field name="length"            column="length"            type="decimal"  nullable="true" />
-        <field name="contentType"       column="content_type"      type="string"   nullable="true" length="255" />
-        <field name="size"              column="content_size"      type="integer"  nullable="true" />
+        <field name="width"              column="width"                type="integer"  nullable="true" />
+        <field name="height"             column="height"               type="integer"  nullable="true" />
+        <field name="length"             column="length"               type="decimal"  nullable="true" />
+        <field name="contentType"        column="content_type"         type="string"   nullable="true" length="255" />
+        <field name="size"               column="content_size"         type="integer"  nullable="true" />
 
-        <field name="copyright"         column="copyright"         type="string"  nullable="true"/>
-        <field name="authorName"        column="author_name"       type="string"  nullable="true"/>
+        <field name="copyright"          column="copyright"            type="string"  nullable="true"/>
+        <field name="authorName"         column="author_name"          type="string"  nullable="true"/>
 
-        <field name="context"           column="context"           type="string"  nullable="true" length="64"/>
+        <field name="context"            column="context"              type="string"  nullable="true" length="64"/>
 
-        <field name="cdnIsFlushable"    column="cdn_is_flushable"  type="boolean"  nullable="true" default="false" />
-        <field name="cdnFlushAt"        column="cdn_flush_at"      type="datetime" nullable="true"/>
-        <field name="cdnStatus"         column="cdn_status"        type="integer"  nullable="true" />
+        <field name="cdnIsFlushable"     column="cdn_is_flushable"     type="boolean"  nullable="true" default="false" />
+        <field name="cdnFlushIdentifier" column="cdn_flush_identifier" type="string"   nullable="true" length="64" />
+        <field name="cdnFlushAt"         column="cdn_flush_at"         type="datetime" nullable="true"/>
+        <field name="cdnStatus"          column="cdn_status"           type="integer"  nullable="true" />
 
-        <field name="updatedAt"         column="updated_at"     type="datetime" />
-        <field name="createdAt"         column="created_at"     type="datetime" />
+        <field name="updatedAt"          column="updated_at"     type="datetime" />
+        <field name="createdAt"          column="created_at"     type="datetime" />
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />

--- a/Resources/config/doctrine/BaseMedia.phpcr.xml
+++ b/Resources/config/doctrine/BaseMedia.phpcr.xml
@@ -29,6 +29,7 @@
         <field name="context"            type="string" />
 
         <field name="cdnIsFlushable"     type="boolean" nullable="true" />
+        <field name="cdnFlushIdentifier" type="string"  nullable="true" />
         <field name="cdnFlushAt"         type="date" nullable="true" />
         <field name="cdnStatus"          type="long" nullable="true" />
 

--- a/Resources/config/media.xml
+++ b/Resources/config/media.xml
@@ -38,6 +38,13 @@
             <argument />
         </service>
 
+        <service id="sonata.media.cdn.cloudfront" class="Sonata\MediaBundle\CDN\CloudFront">
+            <argument />
+            <argument />
+            <argument />
+            <argument />
+        </service>
+
         <service id="sonata.media.cdn.fallback" class="Sonata\MediaBundle\CDN\Fallback">
             <argument />
             <argument />

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -65,6 +65,12 @@ Full configuration options:
                 password:
                 username:
 
+            cloudfront:
+                path:       http://xxxxxxxxxxxxxx.cloudfront.net/uploads/media
+                distribution_id:
+                key:
+                secret:
+
             fallback:
                 master:     sonata.media.cdn.panther
                 fallback:   sonata.media.cdn.server

--- a/Resources/translations/SonataMediaBundle.bg.xliff
+++ b/Resources/translations/SonataMediaBundle.bg.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Обнови CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Промени видеото</target>

--- a/Resources/translations/SonataMediaBundle.de.xliff
+++ b/Resources/translations/SonataMediaBundle.de.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Flush CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Video ändern</target>

--- a/Resources/translations/SonataMediaBundle.en.xliff
+++ b/Resources/translations/SonataMediaBundle.en.xliff
@@ -230,6 +230,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Flush CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Change video</target>

--- a/Resources/translations/SonataMediaBundle.es.xliff
+++ b/Resources/translations/SonataMediaBundle.es.xliff
@@ -232,7 +232,11 @@
             </trans-unit>
             <trans-unit id="label.cdn_is_flushable">
                 <source>label.cdn_is_flushable</source>
-                <target>Limpiar CDN</target>
+                <target>CDN en purga</target>
+            </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>Identificador purga CDN</target>
             </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>

--- a/Resources/translations/SonataMediaBundle.fi.xliff
+++ b/Resources/translations/SonataMediaBundle.fi.xliff
@@ -230,6 +230,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Huuhdo CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Vaihda video</target>

--- a/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/Resources/translations/SonataMediaBundle.fr.xliff
@@ -238,6 +238,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>À rafraîchir sur le CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Changer la video</target>

--- a/Resources/translations/SonataMediaBundle.hu.xliff
+++ b/Resources/translations/SonataMediaBundle.hu.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>CDN cache törlése</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Videó cseréje</target>

--- a/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/Resources/translations/SonataMediaBundle.lt.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Flush CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Pakeisti video</target>

--- a/Resources/translations/SonataMediaBundle.nl.xliff
+++ b/Resources/translations/SonataMediaBundle.nl.xliff
@@ -230,6 +230,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Flush CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Wijzig video</target>

--- a/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/Resources/translations/SonataMediaBundle.pl.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Wyczyszczony CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Zmień video</target>

--- a/Resources/translations/SonataMediaBundle.pt_BR.xliff
+++ b/Resources/translations/SonataMediaBundle.pt_BR.xliff
@@ -226,6 +226,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Atualizar CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Alterar vídeo</target>

--- a/Resources/translations/SonataMediaBundle.ro.xliff
+++ b/Resources/translations/SonataMediaBundle.ro.xliff
@@ -230,6 +230,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Flush CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Modificați video</target>

--- a/Resources/translations/SonataMediaBundle.ru.xliff
+++ b/Resources/translations/SonataMediaBundle.ru.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Flush CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Сменить видео</target>

--- a/Resources/translations/SonataMediaBundle.sl.xliff
+++ b/Resources/translations/SonataMediaBundle.sl.xliff
@@ -234,6 +234,10 @@
                 <source>label.cdn_is_flushable</source>
                 <target>Izprazni CDN</target>
             </trans-unit>
+            <trans-unit id="label.cdn_flush_identifier">
+                <source>label.cdn_flush_identifier</source>
+                <target>CDN flush identifier</target>
+            </trans-unit>
             <trans-unit id="label.video_reference">
                 <source>label.video_reference</source>
                 <target>Spremeni video</target>

--- a/Tests/CDN/CloudFrontTest.php
+++ b/Tests/CDN/CloudFrontTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\CDN;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class CloudFrontTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCloudFront()
+    {
+        $client = $this->getMock('CloudFrontClientSpy', array('createInvalidation'), array(), '', false);
+        $client->expects($this->exactly(3))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy()));
+
+        $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
+                    ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))
+                    ->setMethods(null)
+                    ->getMock();
+        $cloudFront->setClient($client);
+
+        $this->assertEquals('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
+
+        $path = '/mypath/file.jpg';
+
+        $cloudFront->flushByString($path);
+        $cloudFront->flush($path);
+        $cloudFront->flushPaths(array($path));
+    }
+
+    public function testException()
+    {
+        $this->setExpectedException('\RuntimeException', 'Unable to flush : ');
+        $client = $this->getMock('CloudFrontClientSpy', array('createInvalidation'), array(), '', false);
+        $client->expects($this->exactly(1))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy(true)));
+        $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
+                    ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))
+                    ->setMethods(null)
+                    ->getMock();
+        $cloudFront->setClient($client);
+        $cloudFront->flushPaths(array('boom'));
+    }
+}
+
+class CloudFrontClientSpy
+{
+    public function createInvalidation()
+    {
+        return new CloudFrontResultSpy();
+    }
+}
+
+class CloudFrontResultSpy
+{
+    protected $fail = false;
+
+    public function __construct($fail = false)
+    {
+        $this->fail = $fail;
+    }
+
+    public function get($data)
+    {
+        if ('Status' !== $data || $this->fail) {
+            return;
+        }
+
+        return 'InProgress';
+    }
+}

--- a/Tests/Entity/MediaTest.php
+++ b/Tests/Entity/MediaTest.php
@@ -44,6 +44,7 @@ class MediaTest extends \PHPUnit_Framework_TestCase
         $media->setCopyright('copyleft');
         $media->setAuthorName('Thomas');
         $media->setCdnIsFlushable(true);
+        $media->setCdnFlushIdentifier('identifier_123');
         $media->setCdnFlushAt(new \DateTime);
         $media->setContentType('sonata/media');
         $media->setCreatedAt(new \DateTime);
@@ -56,6 +57,7 @@ class MediaTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('copyleft', $media->getCopyright());
         $this->assertEquals('Thomas', $media->getAuthorName());
         $this->assertTrue($media->getCdnIsFlushable());
+        $this->assertEquals('identifier_123', $media->getCdnFlushIdentifier());
         $this->assertInstanceOf('DateTime', $media->getCdnFlushAt());
         $this->assertInstanceOf('DateTime', $media->getCreatedAt());
         $this->assertEquals('sonata/media', $media->getContentType());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Doc PR | none |
- Sanitated starting and ending slashes in CloudFront::getPath()
- Replaced short array syntax [] in CloudFront::flushPaths() to keep BC with PHP 5.3
- Updated CloudFront CDN in order to throw custom exception while wrong paths given.
- Added unit tests for CloudFront.
- Added property "cdnFlushIdentifier" in BaseMedia.
- Updated CDNInterface and its implementations (added getFlushStatus() method).
- Added command to update CDN status for medias that are currently flushing.
- Updated translations.
- Normalized paths withouth leading slash.
- Throw exception while empty paths.
- Updated UpdateCdnStatusCommand (added verbose output).
- Normalized paths withouth leading slash.
- Added BaseProvider::flushCdn() method.
- Added check in BaseProvider to ensure CDN flush only in pre-existent medias.
- Bugfix in UpdateCdnStatusCommand.
